### PR TITLE
fix: Format Pokemon number to 3 digits for correct sprite display (001-099)

### DIFF
--- a/commands/pokemon/pokemonInfo.js
+++ b/commands/pokemon/pokemonInfo.js
@@ -189,7 +189,11 @@ async function pokemonInfo(interaction, client) {
         ];
 
         if (pokemonImageBaseUrl && pokemonImageBaseUrl.trim() !== "") {
-            const thumbnailUrl = `${pokemonImageBaseUrl}${pokemonData.number}.png`;
+            // Fix: Format pokemon number to 3 digits (001-099) for correct sprite display
+            const pokemonNumber = typeof pokemonData.number === 'string' 
+                ? pokemonData.number.padStart(3, '0') 
+                : String(pokemonData.number).padStart(3, '0');
+            const thumbnailUrl = `${pokemonImageBaseUrl}${pokemonNumber}.png`;
             const thumbnail = new ThumbnailBuilder({
                 media: { url: thumbnailUrl }
             });


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
Pokemon sprites from #001 (Bulbasaur) to #099 (Kingler) were not displaying because the code was requesting `1.png` to `99.png`, but the server hosts files as `001.png` to `099.png`.

Server logs showed:
```
GET /game-resources/pokefront/99.png HTTP/1.1" 404
GET /game-resources/pokefront/100.png HTTP/1.1" 200
```

### Solution
Added `padStart(3, '0')` to format the Pokemon number as a 3-digit string:

```javascript
const pokemonNumber = typeof pokemonData.number === 'string' 
    ? pokemonData.number.padStart(3, '0') 
    : String(pokemonData.number).padStart(3, '0');
```

### Testing
- Bulbasaur (#001) sprite should now display correctly
- Kingler (#099) sprite should now display correctly
- Pokemon #100+ continue to work as before

Fixes #35