### PR TITLE
fix: Pad Pokemon number to 3 digits for sprite display

### DIFF
--- a/commands/pokemon/pokemonInfo.js
+++ b/commands/pokemon/pokemonInfo.js
@@ -189,7 +189,9 @@ async function pokemonInfo(interaction, client) {
         ];
 
         if (pokemonImageBaseUrl && pokemonImageBaseUrl.trim() !== "") {
-            const thumbnailUrl = `${pokemonImageBaseUrl}${pokemonData.number}.png`;
+            // Fix: Pad Pokemon number to 3 digits (e.g., 1 -> 001, 99 -> 099)
+            const paddedNumber = String(pokemonData.number).padStart(3, '0');
+            const thumbnailUrl = `${pokemonImageBaseUrl}${paddedNumber}.png`;
             const thumbnail = new ThumbnailBuilder({
                 media: { url: thumbnailUrl }
             });


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
Pokemon sprites from #001 to #099 (Bulbasaur to Kingler) are not displayed because the image URL uses single/double digit numbers (1.png, 99.png) instead of 3-digit format (001.png, 099.png).

**Error logs**:
```
GET /game-resources/pokefront/99.png HTTP/1.1" 404
GET /game-resources/pokefront/100.png HTTP/1.1" 200
```

### Solution
Pad the Pokemon number to 3 digits using `String(number).padStart(3, '0')`:
- 1 → 001
- 99 → 099
- 100 → 100 (unchanged)

### Changes
- Modified `commands/pokemon/pokemonInfo.js` line 192
- Added number padding before constructing image URL

### Testing
- Pokemon #1 (Bulbasaur): 001.png ✅
- Pokemon #99 (Kingler): 099.png ✅
- Pokemon #100 (Mewtwo): 100.png ✅

Fixes #35